### PR TITLE
Fix for empty link response header

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ First, add the following to your pubspec.yaml:
 
 ```yaml
 dependencies:
-  github: ">=2.2.3 <2.2.3"
+  github: ">=2.2.3 <3.0.0"
 ```
 
 Then import the library and use it:

--- a/lib/src/common/util/pagination.dart
+++ b/lib/src/common/util/pagination.dart
@@ -30,7 +30,13 @@ class PaginationHelper<T> {
         break;
       }
 
-      var info = parseLinkHeader(response.headers['link']);
+      var link = response.headers['link'];
+
+      if (link == null) {
+        break;
+      }
+
+      var info = parseLinkHeader(link);
       if (info == null) {
         break;
       }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: github
-version: 2.2.3
+version: 2.2.3+1
 author: Kenneth Endfinger <kaendfinger@gmail.com>
 description: GitHub API Client Library
 homepage: https://github.com/DirectMyFile/github.dart


### PR DESCRIPTION
Also note: you should encourage folks to use a wider version range on your package.

You should release `3.0.0` if you ever make breaking changes to the API.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/directmyfile/github.dart/59)
<!-- Reviewable:end -->
