### PR TITLE
remove `public` parameter from editGist and make `files` parameter optional

### DIFF
--- a/lib/src/common/gists_service.dart
+++ b/lib/src/common/gists_service.dart
@@ -85,23 +85,21 @@ class GistsService extends Service {
   /// Edits a Gist.
   ///
   /// API docs: https://developer.github.com/v3/gists/#edit-a-gist
-  Future<Gist> editGist(String id, Map<String, String> files,
-      {String description, bool public: false}) {
-    var map = {"files": {}};
+  Future<Gist> editGist(String id, {String description, Map<String, String> files
+  }) {
+    var map = {};
 
     if (description != null) {
       map["description"] = description;
     }
 
-    map["public"] = public;
-
-    var f = {};
-
-    for (var key in files.keys) {
-      f[key] = files[key] == null ? null : {"content": files[key]};
+    if (files != null) {
+      var f = {};
+      for (var key in files.keys) {
+        f[key] = files[key] == null ? null : {"content": files[key]};
+      }
+      map["files"] = f;
     }
-
-    map["files"] = f;
 
     return _github.postJSON("/gists/${id}",
         statusCode: 200, body: JSON.encode(map), convert: Gist.fromJSON);


### PR DESCRIPTION
The public parameter doesn't seem to do anything. I made the files paramater optinal, as it is possible to not edit any files, but just edit the description.