### PR TITLE
Propogate error back to the caller

### DIFF
--- a/lib/server.dart
+++ b/lib/server.dart
@@ -117,8 +117,8 @@ class _IOClient extends http.Client {
 
         var resp = new http.Response(value, map, response.statusCode);
         completer.complete(resp);
-      });
-    });
+      }).catchError(completer.completeError);
+    }).catchError(completer.completeError);
 
     return completer.future;
   }


### PR DESCRIPTION
`req.write(request.body)` might fail because of encoding issue. It is better to propagate the error back to the caller for debugging.
