### PR TITLE
Fix usage in browser

### DIFF
--- a/lib/browser.dart
+++ b/lib/browser.dart
@@ -4,6 +4,8 @@
 
 library github.browser;
 
+import 'package:http/browser_client.dart';
+
 import "src/common.dart";
 
 export "src/browser/helper.dart";
@@ -12,5 +14,6 @@ export "src/common.dart";
 /// Creates a GitHub Client
 GitHub createGitHubClient(
     {Authentication auth, String endpoint: "https://api.github.com"}) {
-  return new GitHub(auth: auth, endpoint: endpoint);
+  return new GitHub(
+      auth: auth, client: new BrowserClient(), endpoint: endpoint);
 }

--- a/lib/src/common/util/errors.dart
+++ b/lib/src/common/util/errors.dart
@@ -47,7 +47,7 @@ class TeamNotFound extends NotFound {
 
 /// Access was forbidden to a resource
 class AccessForbidden extends GitHubError {
-  AccessForbidden(GitHub github) : super(github, "Access Forbbidden");
+  AccessForbidden(GitHub github) : super(github, "Access Forbidden");
 }
 
 /// Client hit the rate limit.


### PR DESCRIPTION
It appears that in v3.0.0, a switch was made to use the `http` package. By default, this package uses an IOClient (dependent on `dart:io`). In order to use the `http` package in the browser, you have to import the `browser_client.dart` entry point and use that client instead of the default one.

When constructing an instance of `GitHub`, a `Client` can be passed in, but if it isn't, it will construct the default `Client` from the `http` package (see https://github.com/DirectMyFile/github.dart/blob/master/lib/src/common/github.dart#L50). In other words, if you don't pass in an instance of `Client`, the resulting `GitHub` instance will not work in the browser because it will be using an `IOClient`.

Unfortunately, the `browser.dart` entry point for this package does not pass in a `BrowserClient` when constructing the `GitHub` instance in `createGitHubClient()`, and as such is unusable in the browser.

```
Unsupported operation: IOClient isn't supported on this platform.
#0      assertSupported (package:http/src/io.dart:46:3)
#1      Client.Client (package:http/src/client.dart:46:5)
#2      GitHub.GitHub (package:github/src/common/github.dart:87:44)
#3      createGitHubClient (package:github/browser.dart:19:14)
```

---

This PR fixes the above issue by importing the `http` package and constructing a `BrowserClient` instance to pass into the `GitHub` instance.

@kaendfinger @Pacane 