### PR TITLE
Updated options for list method.

### DIFF
--- a/lib/src/common/pulls_service.dart
+++ b/lib/src/common/pulls_service.dart
@@ -7,10 +7,26 @@ part of github.common;
 class PullRequestsService extends Service {
   PullRequestsService(GitHub github) : super(github);
 
-  Stream<PullRequest> list(RepositorySlug slug, {int pages}) {
-    return new PaginationHelper(_github).objects(
-        "GET", "/repos/${slug.fullName}/pulls", PullRequest.fromJSON,
-        pages: pages);
+  /// Fetches several pull requests.
+  ///
+  /// API docs: https://developer.github.com/v3/pulls/#list-pull-requests
+  Stream<PullRequest> list(RepositorySlug slug,
+      {int pages,
+      String base,
+      String direction: 'desc',
+      String head,
+      String sort: 'created',
+      String state: 'open'}) {
+    var params = <String, String>{};
+    putValue("base", base, params);
+    putValue("direction", direction, params);
+    putValue("head", head, params);
+    putValue("sort", sort, params);
+    putValue("state", state, params);
+
+    return new PaginationHelper(_github).objects("GET",
+        "/repos/${slug.fullName}/pulls?state=${state}", PullRequest.fromJSON,
+        pages: pages, params: params);
   }
 
   /// Fetches a single pull request.


### PR DESCRIPTION
While attempting to pull down closed pull requests, I noticed this was not possible as I could not specify the 'state' of the pull requests I wanted to retrieve.  Several other supported parameters are not included in this implementation. (https://developer.github.com/v3/pulls/#list-pull-requests )

This pr fixes this issue by including these additional parameters.

For your consideration : 
@kaendfinger @kevmoo @Pacane @marcojakob 