### PR TITLE
fix for creating a pull request.

### DIFF
--- a/lib/src/common/pulls_service.dart
+++ b/lib/src/common/pulls_service.dart
@@ -40,7 +40,7 @@ class PullRequestsService extends Service {
   ///
   /// API docs: https://developer.github.com/v3/pulls/#create-a-pull-request
   Future<PullRequestInformation> create(
-      RepositorySlug slug, CreateRelease request) {
+      RepositorySlug slug, CreatePullRequest request) {
     return _github.postJSON("/repos/${slug.fullName}/pulls",
         convert: PullRequestInformation.fromJSON,
         body: request.toJSON()) as Future<PullRequestInformation>;


### PR DESCRIPTION
## Problem
We would like to create a pull request.  It seems fairly intentional for us to use the pulls_service.dart, yet when we look at the `create` method, it seems to imply creating a release, not a pull request?
```dart
/// Creates a Pull Request based on the given [request].
  ///
  /// API docs: https://developer.github.com/v3/pulls/#create-a-pull-request
  Future<PullRequestInformation> create(
      RepositorySlug slug, CreateRelease request) {
    return _github.postJSON("/repos/${slug.fullName}/pulls",
        convert: PullRequestInformation.fromJSON,
        body: request.toJSON()) as Future<PullRequestInformation>;
  }
```
( from https://github.com/DirectMyFile/github.dart/blob/ef26ddf899ba725e88b8b1ad6323d30218c85867/lib/src/common/pulls_service.dart#L23 )

It seems like this method should be using the `CreatePullRequest` type instead.