### PR TITLE
Add basic Travis CI run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ addons:
 dart:
   - stable
 dart_task:
-  - test: --platform vm
-  - test: --platform chrome
+  # TODO enable once tests are working
+  # - test: --platform vm
+  # - test: --platform chrome
   - dartanalyzer: lib example test
   - dartfmt: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ addons:
 dart:
   - stable
 dart_task:
-  # TODO enable once tests are working
+  # TODO enable once automated tests are working
   # - test: --platform vm
   # - test: --platform chrome
-  - dartanalyzer: lib example test
+  - dartanalyzer: lib test # TODO fix examples and add example dir
   - dartfmt: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: dart
+sudo: required
+addons:
+  chrome: stable
+dart:
+  - stable
+dart_task:
+  - test: --platform vm
+  - test: --platform chrome
+  - dartanalyzer: lib example test
+  - dartfmt: true


### PR DESCRIPTION
# Overview
This adds an initial .travis.yml file to run Travis CI. 
It currently avoids running dart analyzer on the example directory as it seems that there are errors in master and will be fixed in a separate PR.
The tests are currently commented out and will be enabled in a separate PR with test fixes.