### PR TITLE
fix casts in issue parsing

### DIFF
--- a/lib/src/common/model/issues.dart
+++ b/lib/src/common/model/issues.dart
@@ -61,8 +61,9 @@ class Issue {
   static Issue fromJSON(Map<String, dynamic> input) {
     if (input == null) return null;
 
-    var labels = input['labels'] as List<Map<String, dynamic>>;
-    if (labels == null) labels = [];
+    List<Map<String, Object>> labels =
+        input['labels'].cast<Map<String, dynamic>>();
+    if (labels == null) labels = <Map<String, dynamic>>[];
 
     return new Issue()
       ..id = input['id']


### PR DESCRIPTION
Fixes: #124.

Validated w/

```dart
var github = createGitHubClient();
var slug = RepositorySlug('dart-lang', 'linter');
var issues = await github.issues.listByRepo(slug).toList();
print(issues.length);
```

which prints:

```
231
```

👍 

/cc @robbecker-wf 