### PR TITLE
Prepare for upcoming change to HttpRequest and HttpClientResponse

### DIFF
--- a/lib/src/server/hooks.dart
+++ b/lib/src/server/hooks.dart
@@ -25,7 +25,7 @@ class HookMiddleware {
       return;
     }
 
-    request.transform(const Utf8Decoder()).join().then((content) {
+    const Utf8Decoder().bind(request).join().then((content) {
       _eventController.add(HookEvent.fromJSON(
           request.headers.value("X-GitHub-Event"),
           jsonDecode(content) as Map<String, dynamic>));


### PR DESCRIPTION
An upcoming change to the Dart SDK will change `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900