### PR TITLE
Update readme to use ^5.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ First, add the following to your pubspec.yaml:
 
 ```yaml
 dependencies:
-  github: ^4.0.0
+  github: ^5.0.0
 ```
 
 Then import the library and use it:


### PR DESCRIPTION
Now that v5 is released, update the readme to suggest using that version.