### PR TITLE
updateFile request must be a PUT

### DIFF
--- a/lib/src/common/github.dart
+++ b/lib/src/common/github.dart
@@ -201,7 +201,7 @@ class GitHub {
           convert: convert,
           preview: preview);
 
-  /// Handles Post Requests that respond with JSO
+  /// Handles Post Requests that respond with JSON
   ///
   /// [path] can either be a path like '/repos' or a full url.
   /// [statusCode] is the expected status code. If it is null, it is ignored.
@@ -228,6 +228,41 @@ class GitHub {
           String body,
           String preview}) =>
       _requestJson('POST', path,
+          statusCode: statusCode,
+          fail: fail,
+          headers: headers,
+          params: params,
+          convert: convert,
+          body: body,
+          preview: preview);
+
+  /// Handles Put Requests that respond with JSON
+  ///
+  /// [path] can either be a path like '/repos' or a full url.
+  /// [statusCode] is the expected status code. If it is null, it is ignored.
+  /// If the status code that the response returns is not the status code you provide
+  /// then the [fail] function will be called with the HTTP Response.
+  ///
+  /// If you don't throw an error or break out somehow, it will go into some error checking
+  /// that throws exceptions when it finds a 404 or 401. If it doesn't find a general HTTP Status Code
+  /// for errors, it throws an Unknown Error.
+  ///
+  /// [headers] are HTTP Headers. If it doesn't exist, the 'Accept' and 'Authorization' headers are added.
+  /// [params] are query string parameters.
+  /// [convert] is a simple function that is passed this [GitHub] instance and a JSON object.
+  ///
+  /// The future will pass the object returned from this function to the then method.
+  /// The default [convert] function returns the input object.
+  /// [body] is the data to send to the server.
+  Future<T> putJSON<S, T>(String path,
+          {int statusCode,
+          void fail(http.Response response),
+          Map<String, String> headers,
+          Map<String, String> params,
+          JSONConverter<S, T> convert,
+          String body,
+          String preview}) =>
+      _requestJson('PUT', path,
           statusCode: statusCode,
           fail: fail,
           headers: headers,

--- a/lib/src/common/github.dart
+++ b/lib/src/common/github.dart
@@ -236,41 +236,6 @@ class GitHub {
           body: body,
           preview: preview);
 
-  /// Handles Put Requests that respond with JSON
-  ///
-  /// [path] can either be a path like '/repos' or a full url.
-  /// [statusCode] is the expected status code. If it is null, it is ignored.
-  /// If the status code that the response returns is not the status code you provide
-  /// then the [fail] function will be called with the HTTP Response.
-  ///
-  /// If you don't throw an error or break out somehow, it will go into some error checking
-  /// that throws exceptions when it finds a 404 or 401. If it doesn't find a general HTTP Status Code
-  /// for errors, it throws an Unknown Error.
-  ///
-  /// [headers] are HTTP Headers. If it doesn't exist, the 'Accept' and 'Authorization' headers are added.
-  /// [params] are query string parameters.
-  /// [convert] is a simple function that is passed this [GitHub] instance and a JSON object.
-  ///
-  /// The future will pass the object returned from this function to the then method.
-  /// The default [convert] function returns the input object.
-  /// [body] is the data to send to the server.
-  Future<T> putJSON<S, T>(String path,
-          {int statusCode,
-          void fail(http.Response response),
-          Map<String, String> headers,
-          Map<String, String> params,
-          JSONConverter<S, T> convert,
-          String body,
-          String preview}) =>
-      _requestJson('PUT', path,
-          statusCode: statusCode,
-          fail: fail,
-          headers: headers,
-          params: params,
-          convert: convert,
-          body: body,
-          preview: preview);
-
   Future<T> _requestJson<S, T>(
     String method,
     String path, {

--- a/lib/src/common/repos_service.dart
+++ b/lib/src/common/repos_service.dart
@@ -354,10 +354,13 @@ class RepositoriesService extends Service {
     var map = createNonNullMap(
         {"message": message, "content": content, "sha": sha, "branch": branch});
 
-    return _github.putJSON("/repos/${slug.fullName}/contents/$path",
-        body: jsonEncode(map),
-        statusCode: 200,
-        convert: ContentCreation.fromJSON);
+    return _github
+        .request("PUT", "/repos/${slug.fullName}/contents/$path",
+            body: jsonEncode(map))
+        .then((response) {
+      return ContentCreation.fromJSON(
+          jsonDecode(response.body) as Map<String, dynamic>);
+    });
   }
 
   /// Deletes the specified file.

--- a/lib/src/common/repos_service.dart
+++ b/lib/src/common/repos_service.dart
@@ -354,7 +354,7 @@ class RepositoriesService extends Service {
     var map = createNonNullMap(
         {"message": message, "content": content, "sha": sha, "branch": branch});
 
-    return _github.postJSON("/repos/${slug.fullName}/contents/$path",
+    return _github.putJSON("/repos/${slug.fullName}/contents/$path",
         body: jsonEncode(map),
         statusCode: 200,
         convert: ContentCreation.fromJSON);


### PR DESCRIPTION
I was trying to use this API but ended up with `Not Found` messages. While debugging, I've discovered [`updatefile`](https://developer.github.com/v3/repos/contents/#create-or-update-a-file) request must be done with `PUT` command (and not `POST`, as this library was doing).

Warning: there may be otherrequests that must be done with `PUT` method!