### PR TITLE
Add the ability to upload release assets. Add the ability to get an existing release by tag name.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## v5.3.0
+- Add the ability to upload release assets.
+- Add the ability to get an existing release by tag name. 
+
+BREAKING CHANGES: 
+- The `draft` and `prerelease` properties in the CreateRelease and Release 
+- classes have been renamed to `isDraft` and `isPrerelease` for clarity.
+- Release.targetCommitsh has been renamed to Release.targetCommitish. (spelling)
+- The `release` parameter in RepositoriesService.createRelease 
+has been renamed to `createRelease`.
+- `RepositoriesService.getRelease` has been renamed to `RepositoriesService.getReleaseById`
+
 ## v5.2.0
  - Add access to labels on Pull Requests https://github.com/DirectMyFile/github.dart/pull/163
  - Adding draft property to PR model https://github.com/DirectMyFile/github.dart/pull/162

--- a/lib/server.dart
+++ b/lib/server.dart
@@ -11,8 +11,10 @@ export "src/server/hooks.dart";
 /// Creates a GitHub Client.
 /// If [auth] is not specified, then it will be automatically configured
 /// from the environment as per [findAuthenticationFromEnvironment].
-GitHub createGitHubClient(
-    {Authentication auth, String endpoint = "https://api.github.com"}) {
+GitHub createGitHubClient({
+  Authentication auth,
+  String endpoint = "https://api.github.com",
+}) {
   if (auth == null) {
     auth = findAuthenticationFromEnvironment();
   }

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -27,7 +27,6 @@ export 'common/model/repos_releases.dart';
 export "common/model/users.dart";
 export "common/util/pagination.dart";
 
-part "common.g.dart";
 part "common/activity_service.dart";
 part "common/authorizations_service.dart";
 part "common/gists_service.dart";
@@ -68,6 +67,7 @@ part "common/util/json.dart";
 part "common/util/oauth2.dart";
 part "common/util/service.dart";
 part "common/util/utils.dart";
+part "common.g.dart";
 
 void _applyExpandos(Object target, http.Response response) {
   _etagExpando[target] = response.headers['etag'];

--- a/lib/src/common/github.dart
+++ b/lib/src/common/github.dart
@@ -40,11 +40,11 @@ class GitHub {
   ///
   /// [endpoint] is the api endpoint to use
   /// [auth] is the authentication information
-  GitHub(
-      {Authentication auth,
-      this.endpoint = "https://api.github.com",
-      http.Client client})
-      : this.auth = auth == null ? Authentication.anonymous() : auth,
+  GitHub({
+    Authentication auth,
+    this.endpoint = "https://api.github.com",
+    http.Client client,
+  })  : this.auth = auth == null ? Authentication.anonymous() : auth,
         this.client = client == null ? http.Client() : client;
 
   /// The maximum number of requests that the consumer is permitted to make per
@@ -219,22 +219,29 @@ class GitHub {
   /// The future will pass the object returned from this function to the then method.
   /// The default [convert] function returns the input object.
   /// [body] is the data to send to the server.
-  Future<T> postJSON<S, T>(String path,
-          {int statusCode,
-          void fail(http.Response response),
-          Map<String, String> headers,
-          Map<String, String> params,
-          JSONConverter<S, T> convert,
-          String body,
-          String preview}) =>
-      _requestJson('POST', path,
-          statusCode: statusCode,
-          fail: fail,
-          headers: headers,
-          params: params,
-          convert: convert,
-          body: body,
-          preview: preview);
+  /// [S] represents the input type.
+  /// [T] represents the type return from this function after conversion
+  Future<T> postJSON<S, T>(
+    String path, {
+    int statusCode,
+    void fail(http.Response response),
+    Map<String, String> headers,
+    Map<String, String> params,
+    JSONConverter<S, T> convert,
+    dynamic body,
+    String preview,
+  }) =>
+      _requestJson(
+        'POST',
+        path,
+        statusCode: statusCode,
+        fail: fail,
+        headers: headers,
+        params: params,
+        convert: convert,
+        body: body,
+        preview: preview,
+      );
 
   Future<T> _requestJson<S, T>(
     String method,
@@ -244,7 +251,7 @@ class GitHub {
     Map<String, String> headers,
     Map<String, String> params,
     JSONConverter<S, T> convert,
-    String body,
+    dynamic body,
     String preview,
   }) async {
     convert ??= (input) => input as T;
@@ -256,12 +263,15 @@ class GitHub {
 
     headers.putIfAbsent("Accept", () => "application/vnd.github.v3+json");
 
-    var response = await request(method, path,
-        headers: headers,
-        params: params,
-        body: body,
-        statusCode: statusCode,
-        fail: fail);
+    var response = await request(
+      method,
+      path,
+      headers: headers,
+      params: params,
+      body: body,
+      statusCode: statusCode,
+      fail: fail,
+    );
 
     var json = jsonDecode(response.body);
 
@@ -283,13 +293,16 @@ class GitHub {
   /// [params] are query string parameters.
   /// [body] is the body content of requests that take content.
   ///
-  Future<http.Response> request(String method, String path,
-      {Map<String, String> headers,
-      Map<String, dynamic> params,
-      String body,
-      int statusCode,
-      void fail(http.Response response),
-      String preview}) async {
+  Future<http.Response> request(
+    String method,
+    String path, {
+    Map<String, String> headers,
+    Map<String, dynamic> params,
+    dynamic body,
+    int statusCode,
+    void fail(http.Response response),
+    String preview,
+  }) async {
     if (headers == null) headers = {};
 
     if (preview != null) {
@@ -331,7 +344,11 @@ class GitHub {
     var request = http.Request(method, Uri.parse(url.toString()));
     request.headers.addAll(headers);
     if (body != null) {
-      request.body = body;
+      if (body is String) {
+        request.body = body;
+      } else {
+        request.bodyBytes = body;
+      }
     }
 
     var streamedResponse = await client.send(request);

--- a/lib/src/common/model/repos_releases.dart
+++ b/lib/src/common/model/repos_releases.dart
@@ -1,5 +1,8 @@
+import 'dart:typed_data';
+
 import 'package:github/src/common/model/users.dart';
 import 'package:json_annotation/json_annotation.dart';
+import 'package:meta/meta.dart';
 
 part 'repos_releases.g.dart';
 
@@ -21,8 +24,16 @@ class Release {
   @JsonKey(name: "zipball_url")
   String zipballUrl;
 
+  /// The endpoint for uploading release assets.
+  /// This key is a hypermedia resource. https://developer.github.com/v3/#hypermedia
+  @JsonKey(name: "upload_url")
+  String uploadUrl;
+
   /// Release ID
   int id;
+
+  @JsonKey(name: "node_id")
+  String nodeId;
 
   /// Release Tag Name
   @JsonKey(name: "tag_name")
@@ -30,7 +41,7 @@ class Release {
 
   /// Target Commit
   @JsonKey(name: "target_commitish")
-  String targetCommitsh;
+  String targetCommitish;
 
   /// Release Name
   String name;
@@ -42,10 +53,12 @@ class Release {
   String description;
 
   /// If the release is a draft.
-  bool draft;
+  @JsonKey(name: "draft")
+  bool isDraft;
 
   /// If the release is a pre-release.
-  bool prerelease;
+  @JsonKey(name: "prerelease")
+  bool isPrerelease;
 
   /// The time this release was created at.
   @JsonKey(name: "created_at")
@@ -77,6 +90,14 @@ class Release {
   Map<String, dynamic> toJson() {
     return _$ReleaseToJson(this);
   }
+
+  String getUploadUrlFor(String name, [String label]) =>
+      "${uploadUrl.substring(0, uploadUrl.indexOf('{'))}?name=$name${label != null ? ",$label" : ""}";
+
+  bool get hasErrors =>
+      json['errors'] != null && (json['errors'] as List).isNotEmpty;
+
+  List get errors => json['errors'];
 }
 
 /// Model class for a release asset.
@@ -151,12 +172,21 @@ class CreateRelease {
   String body;
 
   /// If the release is a draft
-  bool draft;
+  bool isDraft;
 
   /// If the release should actually be released.
-  bool prerelease;
+  bool isPrerelease;
 
   CreateRelease(this.tagName);
+
+  CreateRelease.from({
+    @required this.tagName,
+    @required this.name,
+    @required this.targetCommitish,
+    @required this.isDraft,
+    @required this.isPrerelease,
+    this.body,
+  });
 
   static CreateRelease fromJson(Map<String, dynamic> input) {
     if (input == null) return null;
@@ -167,4 +197,31 @@ class CreateRelease {
   Map<String, dynamic> toJson() {
     return _$CreateReleaseToJson(this);
   }
+}
+
+class CreateReleaseAsset {
+  /// The file name of the asset.
+  String name;
+
+  /// An alternate short description of the asset. Used in place of the filename.
+  String label;
+
+  /// The media type of the asset.
+  ///
+  /// For a list of media types,
+  /// see [Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml).
+  /// For example: application/zip
+  String contentType;
+
+  /// The raw binary data for the asset being uploaded.
+  ///
+  /// GitHub expects the asset data in its raw binary form, rather than JSON.
+  Uint8List assetData;
+
+  CreateReleaseAsset({
+    @required this.name,
+    @required this.contentType,
+    @required this.assetData,
+    this.label,
+  });
 }

--- a/lib/src/common/model/repos_releases.g.dart
+++ b/lib/src/common/model/repos_releases.g.dart
@@ -11,14 +11,16 @@ Release _$ReleaseFromJson(Map<String, dynamic> json) {
     ..htmlUrl = json['html_url'] as String
     ..tarballUrl = json['tarball_url'] as String
     ..zipballUrl = json['zipball_url'] as String
+    ..uploadUrl = json['upload_url'] as String
     ..id = json['id'] as int
+    ..nodeId = json['node_id'] as String
     ..tagName = json['tag_name'] as String
-    ..targetCommitsh = json['target_commitish'] as String
+    ..targetCommitish = json['target_commitish'] as String
     ..name = json['name'] as String
     ..body = json['body'] as String
     ..description = json['description'] as String
-    ..draft = json['draft'] as bool
-    ..prerelease = json['prerelease'] as bool
+    ..isDraft = json['draft'] as bool
+    ..isPrerelease = json['prerelease'] as bool
     ..createdAt = json['created_at'] == null
         ? null
         : DateTime.parse(json['created_at'] as String)
@@ -38,18 +40,20 @@ Map<String, dynamic> _$ReleaseToJson(Release instance) => <String, dynamic>{
       'html_url': instance.htmlUrl,
       'tarball_url': instance.tarballUrl,
       'zipball_url': instance.zipballUrl,
+      'upload_url': instance.uploadUrl,
       'id': instance.id,
+      'node_id': instance.nodeId,
       'tag_name': instance.tagName,
-      'target_commitish': instance.targetCommitsh,
+      'target_commitish': instance.targetCommitish,
       'name': instance.name,
       'body': instance.body,
       'description': instance.description,
-      'draft': instance.draft,
-      'prerelease': instance.prerelease,
+      'draft': instance.isDraft,
+      'prerelease': instance.isPrerelease,
       'created_at': instance.createdAt?.toIso8601String(),
       'published_at': instance.publishedAt?.toIso8601String(),
-      'author': Release._authorToJson(instance.author),
-      'assets': Release._assetsToJson(instance.assets),
+      'author': instance.author,
+      'assets': instance.assets,
     };
 
 ReleaseAsset _$ReleaseAssetFromJson(Map<String, dynamic> json) {
@@ -92,8 +96,8 @@ CreateRelease _$CreateReleaseFromJson(Map<String, dynamic> json) {
     ..targetCommitish = json['target_commitish'] as String
     ..name = json['name'] as String
     ..body = json['body'] as String
-    ..draft = json['draft'] as bool
-    ..prerelease = json['prerelease'] as bool;
+    ..isDraft = json['isDraft'] as bool
+    ..isPrerelease = json['isPrerelease'] as bool;
 }
 
 Map<String, dynamic> _$CreateReleaseToJson(CreateRelease instance) =>
@@ -103,6 +107,6 @@ Map<String, dynamic> _$CreateReleaseToJson(CreateRelease instance) =>
       'target_commitish': instance.targetCommitish,
       'name': instance.name,
       'body': instance.body,
-      'draft': instance.draft,
-      'prerelease': instance.prerelease,
+      'isDraft': instance.isDraft,
+      'isPrerelease': instance.isPrerelease,
     };


### PR DESCRIPTION
BREAKING CHANGES:
- The "draft" and "prerelease" properties in the CreateRelease and Release
- classes have been renamed to "isDraft" and "isPrerelease" for clarity.
- Release.targetCommitsh has been renamed to Release.targetCommitish. (spelling)
- The "release" parameter in RepositoriesService.createRelease
has been renamed to "createRelease".
- RepositoriesService.getRelease has been renamed to "RepositoriesService.getReleaseById"