### PR TITLE
Fix naming targetCommitsh to targetCommitish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v5.3.0
+ - Release.targetCommitsh is now deprecated. Use targetCommitish instead.
+
 ## v5.2.0
  - Add access to labels on Pull Requests https://github.com/DirectMyFile/github.dart/pull/163
  - Adding draft property to PR model https://github.com/DirectMyFile/github.dart/pull/162

--- a/lib/src/common/model/repos_releases.dart
+++ b/lib/src/common/model/repos_releases.dart
@@ -30,7 +30,15 @@ class Release {
 
   /// Target Commit
   @JsonKey(name: "target_commitish")
-  String targetCommitsh;
+  String targetCommitish;
+
+  /// Target Commit (Deprecated)
+  ///
+  /// `targetCommitsh` was a typo in previous versions and has been corrected.
+  /// Use `targetCommitish` instead.
+  /// This will be removed in the next major release
+  @deprecated
+  String get targetCommitsh => targetCommitish;
 
   /// Release Name
   String name;

--- a/lib/src/common/model/repos_releases.g.dart
+++ b/lib/src/common/model/repos_releases.g.dart
@@ -13,7 +13,7 @@ Release _$ReleaseFromJson(Map<String, dynamic> json) {
     ..zipballUrl = json['zipball_url'] as String
     ..id = json['id'] as int
     ..tagName = json['tag_name'] as String
-    ..targetCommitsh = json['target_commitish'] as String
+    ..targetCommitish = json['target_commitish'] as String
     ..name = json['name'] as String
     ..body = json['body'] as String
     ..description = json['description'] as String
@@ -40,7 +40,7 @@ Map<String, dynamic> _$ReleaseToJson(Release instance) => <String, dynamic>{
       'zipball_url': instance.zipballUrl,
       'id': instance.id,
       'tag_name': instance.tagName,
-      'target_commitish': instance.targetCommitsh,
+      'target_commitish': instance.targetCommitish,
       'name': instance.name,
       'body': instance.body,
       'description': instance.description,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: github
-version: 5.2.0
+version: 5.3.0
 author: Kenneth Endfinger <kaendfinger@gmail.com>
 description: A high-level GitHub API Client Library that uses Github's v3 API
 homepage: https://github.com/DirectMyFile/github.dart


### PR DESCRIPTION
This fixes the naming of targetCommitsh to targetCommitish in a non-breaking way.